### PR TITLE
Disable 'Start All' button in workflow manager

### DIFF
--- a/components/workflows/workflow-manager.tsx
+++ b/components/workflows/workflow-manager.tsx
@@ -261,10 +261,10 @@ export function WorkflowManager() {
             {t('addFiles')}
           </Button>
 
-          {/* Start All Button */}
+          {/* Start All Button - Disabled */}
           <Button
             onClick={handleStartAll}
-            disabled={!hasPendingWorkflows || isProcessing}
+            disabled={true}
           >
             <Play className="w-4 h-4 mr-2" />
             {t('startAll')}


### PR DESCRIPTION
The 'Start All' button is now always disabled, regardless of workflow state. This may be for testing, UI changes, or to prevent unintended batch actions.